### PR TITLE
Make MODULE_NAME public

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -18,7 +18,7 @@ pub fn expand(mod_block: &ItemMod, attribute_meta: &LitStr) -> Result<TokenStrea
     Ok(quote::quote! {
         #mod_vis mod #mod_name {
             /// Name of the lirbary being hooked
-            const MODULE_NAME: &str = #library_name;
+            pub const MODULE_NAME: &str = #library_name;
             #init_detours_fn
             #(#items)*
             #(#funcs)*


### PR DESCRIPTION
The #[hook_module] macro creates a const &str with the module name, but it wasn't made public, so it was unusable outside of the module. This PR makes it public, so it is easier to check of the module is loaded before calling `init_detours`